### PR TITLE
feat(uv): add uvx utility

### DIFF
--- a/uv/plugin.toml
+++ b/uv/plugin.toml
@@ -25,3 +25,10 @@ checksum-url = "https://github.com/astral-sh/uv/releases/download/{version}/{che
 
 [install.arch]
 x86 = "i686"
+
+[install.exes.uv]
+exe-path = "uv"
+primary = true
+
+[install.exes.uvx]
+exe-path = "uvx"


### PR DESCRIPTION
uv comes with a uvx command that is a shorthand for uv tool run. I added configuration to the existing uv plugin that makes proto find the second executable.